### PR TITLE
Add support for a single string destination

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ module.exports = function(paths, options) {
 	options = options || {};
 	var files = [];
 
+
+	if (typeof (paths) === 'string') { paths = [paths]; }
+
 	var dests = paths.map(function(path) {
 		return gulp.dest(path, options);
 	});


### PR DESCRIPTION
When using this gulp plugin in re-usable tasks, sometimes we don't know if the dest is a string or array of strings. This PR makes both cases supported.